### PR TITLE
Allow service to not be managed, tidy bools

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -11,6 +11,7 @@ class synapse (
   $package_ensure   = $synapse::params::package_ensure,
   $package_provider = $synapse::params::package_provider,
   $package_name     = $synapse::params::package_name,
+  $service_manage   = $synapse::params::service_manage,
   $service_ensure   = $synapse::params::service_ensure,
   $service_enable   = $synapse::params::service_enable,
   $config_file      = $synapse::params::config_file,
@@ -24,8 +25,10 @@ class synapse (
 ) inherits synapse::params {
 
   class { 'synapse::install': } ->
-  class { 'synapse::config': } ~>
-  class { 'synapse::system_service': } ->
-  Class['synapse']
-
+  class { 'synapse::config': }
+  if str2bool($service_manage) {
+    Class['synapse::config'] ~>
+    class { 'synapse::system_service': }
+  }
 }
+

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class synapse::params {
       # Allow logic to change based on requested provider
       $package_name     = undef
       $package_provider = undef
+      $service_manage   = true
       $service_ensure   = 'running'
       $service_enable   = true
       $config_file      = '/etc/synapse/synapse.conf.json'

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -67,7 +67,11 @@ define synapse::service (
     owner   => 'root',
     mode    => '0444',
     content => template('synapse/service.json.erb'),
-    notify  => Service['synapse'],
+  }
+
+  if str2bool($synapse::service_manage) {
+    File[$target] ~> Service['synapse'],
   }
 
 }
+

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -16,7 +16,7 @@ class synapse::system_service {
   } ~>
   service { 'synapse':
     ensure     => $synapse::service_ensure,
-    enable     => $synapse::service_enable,
+    enable     => str2bool($synapse::service_enable),
     hasstatus  => true,
     hasrestart => true,
   }


### PR DESCRIPTION
I'm installing synapse whilst building docker containers. I don't want the service to get touched at all whilst building containers and also I'm not using upstart for process management, so I need to be able to disable..
