### PR TITLE
synapse service should force upstart provider

### DIFF
--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -19,6 +19,7 @@ class synapse::system_service {
     enable     => str2bool($synapse::service_enable),
     hasstatus  => true,
     hasrestart => true,
+    provider   => upstart,
   }
 
 }


### PR DESCRIPTION
This fixes this module on CentOS, where upstart isn't the default service provider.