### PR TITLE
use initctl to control service on redhat 6

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -17,6 +17,7 @@ class synapse (
   $config_file      = $synapse::params::config_file,
   $config_dir       = $synapse::params::config_dir,
   $purge_config     = $synapse::params::purge_config,
+  $log_file         = $synapse::params::log_file,
   $haproxy_ensure   = $synapse::params::haproxy_ensure, 
   $user             = $synapse::params::user,
   $group                   = $synapse::params::group,

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,6 +18,7 @@ class synapse::params {
       $config_file      = '/etc/synapse/synapse.conf.json'
       $config_dir       = '/etc/synapse/conf.d/'
       $purge_config     = true
+      $log_file         = '/var/log/synapse.log'
       $instance_id      = $::fqdn
       $haproxy_ensure   = 'present'
       $user             = 'haproxy'

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -13,12 +13,26 @@ class synapse::system_service {
     group   => 'root',
     mode    => 0444,
     content => template('synapse/synapse.conf.upstart.erb'),
-  } ~>
-  service { 'synapse':
-    ensure     => $synapse::service_ensure,
-    enable     => str2bool($synapse::service_enable),
-    hasstatus  => true,
-    hasrestart => true,
+  }
+
+  if $osfamily == 'RedHat' and $operatingsystemmajrelease == 6 {
+    service { 'synapse':
+      ensure     => $synapse::service_ensure,
+      enable     => false,
+      hasstatus  => true,
+      start      => '/sbin/initctl start synapse',
+      stop       => '/sbin/initctl stop synapse',
+      status     => '/sbin/initctl status synapse | grep "/running" 1>/dev/null 2>&1',
+      subscribe  => File['/etc/init/synapse.conf'],
+    }
+  } else {
+    service { 'synapse':
+      ensure     => $synapse::service_ensure,
+      enable     => str2bool($synapse::service_enable),
+      hasstatus  => true,
+      hasrestart => true,
+      subscribe  => File['/etc/init/synapse.conf'],
+    }
   }
 
 }

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -35,4 +35,12 @@ class synapse::system_service {
     }
   }
 
+  $log_file = $synapse::log_file
+  file { $log_file:
+    ensure => file,
+    owner  => $synapse::user,
+    group  => $synapse::group,
+    mode   => 640,
+  }
+
 }

--- a/templates/synapse.conf.upstart.erb
+++ b/templates/synapse.conf.upstart.erb
@@ -7,4 +7,4 @@ respawn
 respawn limit 10 5
 
 # Backwards compatibility to run as the HAProxy user to give it permission to reload and stuff
-exec su -s /bin/sh -c 'exec "$0" "$@"' <%= scope.lookupvar('synapse::user') -%> -- synapse --config <%= @config_file %>
+exec sudo -u <%= scope.lookupvar('synapse::user') -%> -- synapse --config <%= @config_file %> >> <%= @log_file %> 2>&1


### PR DESCRIPTION
This works around puppet trying to use `service` to control an upstart job on CentOS 6.