### PR TITLE
Re-tool config, initscript, and upgrading

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -33,10 +33,10 @@ class synapse::config (
   $global_config = concat(
     $daemon_config,
     [
-      "user $::synapse::user",
-      "group $::synapse::group",
-      "maxconn 4096",
-      "stats socket $::synapse::stats_socket mode 666 level admin",
+      "user ${::synapse::user}",
+      "group ${::synapse::group}",
+      'maxconn 4096',
+      "stats socket ${::synapse::stats_socket} mode 666 level admin",
     ],
     $::synapse::haproxy_global_log
   )
@@ -73,6 +73,4 @@ class synapse::config (
     purge   => $::synapse::purge_config,
     force   => true,
   }
-
-
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -51,10 +51,9 @@ class synapse::config (
       do_writes        => true,
       do_reloads       => true,
       do_socket        => true,
-      global           => [
-      ],
-      defaults       => $::synapse::haproxy_defaults,
-      extra_sections => $::synapse::haproxy_extra_sections,
+      global           => $global_config,
+      defaults         => $::synapse::haproxy_defaults,
+      extra_sections   => $::synapse::haproxy_extra_sections,
     }
   }, $extra_config)
 

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -38,7 +38,7 @@ class synapse::config (
       "maxconn 4096",
       "stats socket $::synapse::stats_socket mode 666 level admin",
     ],
-    $::synapse_haproxy_global_map
+    $::synapse::haproxy_global_log
   )
 
   $config = merge({

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,7 +41,7 @@ class synapse::config (
     $::synapse::haproxy_global_log
   )
 
-  $config = merge({
+  $config = deep_merge({
     service_conf_dir   => $::synapse::config_dir,
     haproxy            => {
       bind_address     => $haproxy_bind_address,

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -24,7 +24,7 @@ class synapse::config (
     }
   }
 
-  if $daemon {
+  if $haproxy_daemon {
     $daemon_config = ['daemon']
   } else {
     $daemon_config = []

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -7,6 +7,7 @@ class synapse::config (
   $haproxy_reload_command,
   $haproxy_bind_address,
   $haproxy_config_path,
+  $extra_config,
 ) {
 
   # TODO: something?
@@ -14,9 +15,48 @@ class synapse::config (
   if $::synapse::config_file == $::synapse::params::config_file {
     # Make the parent directory
     file { '/etc/synapse/':
-      ensure => 'directory',
+      ensure  => 'directory',
+      owner   => 'root',
+      group   => 'root',
+      recurse => true,
+      purge   => $::synapse::purge_config,
+      force   => true,
     }
   }
+
+  if $daemon {
+    $daemon_config = ['daemon']
+  } else {
+    $daemon_config = []
+  }
+
+  $global_config = concat(
+    $daemon_config,
+    [
+      "user $::synapse::user",
+      "group $::synapse::group",
+      "maxconn 4096",
+      "stats socket $::synapse::stats_socket mode 666 level admin",
+    ],
+    $::synapse_haproxy_global_map
+  )
+
+  $config = merge({
+    service_conf_dir   => $::synapse::config_dir,
+    haproxy            => {
+      bind_address     => $haproxy_bind_address,
+      reload_command   => $haproxy_reload_command,
+      config_file_path => $haproxy_config_path,
+      socket_file_path => $::synapse::stats_socket,
+      do_writes        => true,
+      do_reloads       => true,
+      do_socket        => true,
+      global           => [
+      ],
+      defaults       => $::synapse::haproxy_defaults,
+      extra_sections => $::synapse::haproxy_extra_sections,
+    }
+  }, $extra_config)
 
   file { $::synapse::config_file:
     ensure  => 'present',
@@ -31,7 +71,8 @@ class synapse::config (
     owner   => 'root',
     group   => 'root',
     recurse => true,
-    purge   => $synapse::purge_config,
+    purge   => $::synapse::purge_config,
+    force   => true,
   }
 
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -49,7 +49,7 @@ class synapse (
       'stats refresh 5s',
     ]
   },
-  $extra_config = [],
+  $extra_config = {},
 ) inherits synapse::params {
 
   class { 'synapse::install': } ->

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -60,9 +60,14 @@ class synapse (
     haproxy_config_path    => $haproxy_config_path,
     extra_config           => $extra_config,
   }
+
   if str2bool($service_manage) {
-    Class['synapse::config'] ~>
-    class { 'synapse::system_service': }
+    class { 'synapse::system_service':
+      subscribe => [
+        Class['synapse::install'],
+        Class['synapse::config'],
+      ],
+    }
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -48,7 +48,8 @@ class synapse (
       'stats uri /',
       'stats refresh 5s',
     ]
-  }
+  },
+  $extra_config = [],
 ) inherits synapse::params {
 
   class { 'synapse::install': } ->
@@ -57,6 +58,7 @@ class synapse (
     haproxy_reload_command => $haproxy_reload_command,
     haproxy_bind_address   => $haproxy_bind_address,
     haproxy_config_path    => $haproxy_config_path,
+    extra_config           => $extra_config,
   }
   if str2bool($service_manage) {
     Class['synapse::config'] ~>

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -4,6 +4,7 @@
 # It ensure the service is running
 #
 class synapse::system_service {
+  $user = $synapse::user
 
   # TODO: This assumes upstart. Be more compatible someday
 
@@ -38,7 +39,7 @@ class synapse::system_service {
   $log_file = $synapse::log_file
   file { $log_file:
     ensure => file,
-    owner  => $synapse::user,
+    owner  => $user,
     group  => $synapse::group,
     mode   => '0640',
   }

--- a/spec/classes/synapse_spec.rb
+++ b/spec/classes/synapse_spec.rb
@@ -84,19 +84,19 @@ describe 'synapse' do
   context 'When alternate global log declarations are specified' do
     let(:params) {{ :haproxy_global_log => ['log foo', 'log bar'] }}
     let(:facts)  {{ :osfamily => 'Debian' }}
-    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/"log foo\",\n      \"log bar\",/) }
+    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/"log foo"/).with_content(/"log bar"/) }
   end
 
   context 'When no global log declarations are specified' do
     let(:params) {{  }}
     let(:facts)  {{ :osfamily => 'Debian' }}
-    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/"log     127.0.0.1 local0\",\n      \"log     127.0.0.1 local1 notice\",/) }
+    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/"log     127.0.0.1 local0"/).with_content(/"log     127.0.0.1 local1 notice"/) }
   end
 
   context 'When alternate extra sections are specified' do
     let(:params) {{ :haproxy_extra_sections => {'foo' => ['bar', 'baz']} }}
     let(:facts) {{ :osfamily => 'Debian' }}
-    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/{\n    "foo": \[\n        "bar",\n        "baz"\n    \]\n}/) }
+    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/{\n\s+"foo": \[\n\s+"bar",\n\s+"baz"\n\s+\]\n}/) }
   end
 
   # Service Stuff

--- a/spec/classes/synapse_spec.rb
+++ b/spec/classes/synapse_spec.rb
@@ -96,7 +96,7 @@ describe 'synapse' do
   context 'When alternate extra sections are specified' do
     let(:params) {{ :haproxy_extra_sections => {'foo' => ['bar', 'baz']} }}
     let(:facts) {{ :osfamily => 'Debian' }}
-    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/{\n\s+"foo": \[\n\s+"bar",\n\s+"baz"\n\s+\]\n}/) }
+    it { should contain_file('/etc/synapse/synapse.conf.json').with_content(/{\n\s+"foo": \[\n\s+"bar",\n\s+"baz"\n\s+\]\n\s+}/) }
   end
 
   # Service Stuff

--- a/templates/synapse.conf.json.erb
+++ b/templates/synapse.conf.json.erb
@@ -1,23 +1,2 @@
-<% require 'json' %>{
-  "service_conf_dir": "<%= scope.lookupvar('synapse::config_dir') %>",
-  "haproxy": {
-    "bind_address": "<%= @haproxy_bind_address %>",
-    "reload_command": "<%= @haproxy_reload_command %>",
-    "config_file_path": "<%= @haproxy_config_path %>",
-    "socket_file_path": "<%= scope.lookupvar('synapse::stats_socket') %>",
-    "do_writes": true,
-    "do_reloads": true,
-    "do_socket": true,
-    "global": [
-<%- if @haproxy_daemon -%>      "daemon",
-<%- end -%>
-      "user <%= scope.lookupvar('synapse::user') %>",
-      "group <%= scope.lookupvar('synapse::group') %>",
-      "maxconn 4096",
-      <%= scope.lookupvar('synapse::haproxy_global_log').map {|logline| "\"#{logline}\""}.join(",\n      ") %>,
-      "stats   socket <%= scope.lookupvar('synapse::stats_socket') %> mode 666 level admin"
-    ],
-    "defaults": <%= scope.lookupvar('synapse::haproxy_defaults').to_json %>,
-    "extra_sections": <%= JSON.pretty_generate(scope.lookupvar('synapse::haproxy_extra_sections'), :indent => "    ") %>
-  }
-}
+<% require 'json' -%>
+<% JSON.pretty_generate(@config) %>

--- a/templates/synapse.conf.json.erb
+++ b/templates/synapse.conf.json.erb
@@ -1,2 +1,2 @@
 <% require 'json' -%>
-<% JSON.pretty_generate(@config) %>
+<%= JSON.pretty_generate(@config) %>

--- a/templates/synapse.conf.upstart.erb
+++ b/templates/synapse.conf.upstart.erb
@@ -19,5 +19,5 @@ script
   mkdir -p "$SYNAPSE_WORKING_DIR"
   chown -R <%= @user %> "$SYNAPSE_WORKING_DIR"
 
-  exec setuidgid <%= @user %> -- synapse --config <%= @config_file %> 2>&1
+  exec setuidgid <%= @user %> synapse --config <%= @config_file %> 2>&1
 end script

--- a/templates/synapse.conf.upstart.erb
+++ b/templates/synapse.conf.upstart.erb
@@ -5,7 +5,11 @@ respawn limit 10 5
 
 script
   set -e
-  exec >>"/var/log/synapse/synapse.log"
+
+  # When we no longer need to maintain compatibility with OSes != Ubuntu
+  # Trusty, we can remove this, as Trusty provides logging and log
+  # rotation for free.
+  exec >>"<%= @log_file %>"
 
   # Allow HAProxy to use lots of fds
   ulimit -n 65535

--- a/templates/synapse.conf.upstart.erb
+++ b/templates/synapse.conf.upstart.erb
@@ -1,10 +1,19 @@
-# This file maintained by Puppet!
-# synapse
-
-description	"synapse"
+description "synapse"
 
 respawn
 respawn limit 10 5
 
-# Backwards compatibility to run as the HAProxy user to give it permission to reload and stuff
-exec sudo -u <%= scope.lookupvar('synapse::user') -%> -- synapse --config <%= @config_file %> >> <%= @log_file %> 2>&1
+script
+  set -e
+  exec >>"/var/log/synapse/synapse.log"
+
+  # Allow HAProxy to use lots of fds
+  ulimit -n 65535
+
+  # Create synapse working directory if necessary
+  SYNAPSE_WORKING_DIR=/var/run/synapse
+  mkdir -p "$SYNAPSE_WORKING_DIR"
+  chown -R <%= @user %> "$SYNAPSE_WORKING_DIR"
+
+  exec setuidgid <%= @user %> -- synapse --config <%= @config_file %> 2>&1
+end script


### PR DESCRIPTION
This moves the synapse configuration into the puppet manifest, reducing the responsibility of the conf.json.erb template. We also add a new extra_config variable, which allows arbitrary Synapse configuration to be deep_merged into the existing configuration.

The synapse service now subscribes to the ::install class. Previously, upgrades of a synapse package would not cause the synapse service to restart. In cases where we are responsible for the synapse service, we should also be responsible for restarting it upon upgrade.

Lastly, within the initscript we now mkdir and chown a directory at /var/run/synapse to store ephemeral state.