### PR TITLE
Add the ability to add extra lines to the Synapse init script

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -65,7 +65,7 @@ class synapse (
 
   if str2bool($service_manage) {
     class { 'synapse::system_service':
-      subscribe        => [
+      subscribe => [
         Class['synapse::install'],
         Class['synapse::config'],
       ],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -24,8 +24,9 @@ class synapse (
   $stats_socket            = $synapse::params::stats_socket,
   $haproxy_daemon          = true,
   $haproxy_reload_command  = $synapse::params::haproxy_reload_command,
-  $haproxy_bind_address    = 'localhost',
+  $haproxy_bind_address    = '127.0.0.1',
   $haproxy_config_path     = $synapse::params::haproxy_config_path,
+  $working_dir             = '/var/run/synapse',
   $haproxy_defaults        = [
     'log      global',
     'option   dontlognull',

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -64,7 +64,6 @@ class synapse (
 
   if str2bool($service_manage) {
     class { 'synapse::system_service':
-      extra_init_lines => $extra_init_lines,
       subscribe        => [
         Class['synapse::install'],
         Class['synapse::config'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -50,6 +50,7 @@ class synapse (
     ]
   },
   $extra_config = {},
+  $extra_init_lines = [],
 ) inherits synapse::params {
 
   class { 'synapse::install': } ->
@@ -63,7 +64,8 @@ class synapse (
 
   if str2bool($service_manage) {
     class { 'synapse::system_service':
-      subscribe => [
+      extra_init_lines => $extra_init_lines,
+      subscribe        => [
         Class['synapse::install'],
         Class['synapse::config'],
       ],

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -6,6 +6,7 @@
 class synapse::system_service {
   $user = $::synapse::user
   $extra_init_string = join($::synapse::extra_init_lines, ',')
+  $working_dir = $::synapse::working_dir
 
   # TODO: This assumes upstart. Be more compatible someday
 

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -4,12 +4,12 @@
 # It ensure the service is running
 #
 class synapse::system_service {
-  $user = $synapse::user
-  $extra_init_string = join($extra_init_lines, ',')
+  $user = $::synapse::user
+  $extra_init_string = join($::synapse::extra_init_lines, ',')
 
   # TODO: This assumes upstart. Be more compatible someday
 
-  $config_file = $synapse::config_file
+  $config_file = $::synapse::config_file
   file { '/etc/init/synapse.conf':
     owner   => 'root',
     group   => 'root',
@@ -19,7 +19,7 @@ class synapse::system_service {
 
   if $::osfamily == 'RedHat' and $::operatingsystemmajrelease == 6 {
     service { 'synapse':
-      ensure    => $synapse::service_ensure,
+      ensure    => $::synapse::service_ensure,
       enable    => false,
       hasstatus => true,
       start     => '/sbin/initctl start synapse',
@@ -29,19 +29,19 @@ class synapse::system_service {
     }
   } else {
     service { 'synapse':
-      ensure     => $synapse::service_ensure,
-      enable     => str2bool($synapse::service_enable),
+      ensure     => $::synapse::service_ensure,
+      enable     => str2bool($::synapse::service_enable),
       hasstatus  => true,
       hasrestart => true,
       subscribe  => File['/etc/init/synapse.conf'],
     }
   }
 
-  $log_file = $synapse::log_file
+  $log_file = $::synapse::log_file
   file { $log_file:
     ensure => file,
     owner  => $user,
-    group  => $synapse::group,
+    group  => $::synapse::group,
     mode   => '0640',
   }
 

--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -5,6 +5,7 @@
 #
 class synapse::system_service {
   $user = $synapse::user
+  $extra_init_string = join($extra_init_lines, ',')
 
   # TODO: This assumes upstart. Be more compatible someday
 

--- a/templates/synapse.conf.upstart.erb
+++ b/templates/synapse.conf.upstart.erb
@@ -14,10 +14,11 @@ script
   # Allow HAProxy to use lots of fds
   ulimit -n 65535
 
+  <%= @extra_init_string %>
+
   # Create synapse working directory if necessary
-  SYNAPSE_WORKING_DIR=/var/run/synapse
-  mkdir -p "$SYNAPSE_WORKING_DIR"
-  chown -R <%= @user %> "$SYNAPSE_WORKING_DIR"
+  mkdir -p "<%= @working_dir %>"
+  chown -R <%= @user %> "<%= @working_dir %>"
 
   exec setuidgid <%= @user %> synapse --config <%= @config_file %> 2>&1
 end script


### PR DESCRIPTION
My use-case is that I need to create additional directories before Synapse starts. haproxy-synapse will then place unix sockets within that directory.

So I specify extra_init_lines in my code to create that directory:

```
extra_init_lines       => [
  'mkdir -p /var/run/synapse/sockets',
],
```

The alternative choice is to have a different upstart script set for 'start on starting synapse', but I think this is simpler and worthwhile for other applications as well.