### PR TITLE
Remove hasrestart=>true from Synapse initscript

### DIFF
--- a/manifests/system_service.pp
+++ b/manifests/system_service.pp
@@ -28,11 +28,10 @@ class synapse::system_service {
     }
   } else {
     service { 'synapse':
-      ensure     => $synapse::service_ensure,
-      enable     => str2bool($synapse::service_enable),
-      hasstatus  => true,
-      hasrestart => true,
-      subscribe  => File['/etc/init/synapse.conf'],
+      ensure    => $::synapse::service_ensure,
+      enable    => str2bool($::synapse::service_enable),
+      hasstatus => true,
+      subscribe => File['/etc/init/synapse.conf'],
     }
   }
 


### PR DESCRIPTION
Upstart caches initscripts when you do 'restart' on them, so changes
to the initscript don't get appropriately propagated into the running
system. By setting hasrestart=>false, Puppet will stop then start the
initscript, and upstart will load the new config.